### PR TITLE
Fix/admin access 403

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -7,16 +7,19 @@ from app.utils.template_manager import TemplateManager
 from app.services.email_service import EmailService
 from app.services.jwt_service import decode_token
 from settings.config import Settings
-from fastapi import Depends
+from typing import List  # Added this import
 
+# --- Settings ---
 def get_settings() -> Settings:
     """Return application settings."""
     return Settings()
 
+# --- Email Service ---
 def get_email_service() -> EmailService:
     template_manager = TemplateManager()
     return EmailService(template_manager=template_manager)
 
+# --- Database Session ---
 async def get_db() -> AsyncSession:
     """Dependency that provides a database session for each request."""
     async_session_factory = Database.get_session_factory()
@@ -25,10 +28,11 @@ async def get_db() -> AsyncSession:
             yield session
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
-        
 
+# --- OAuth2 Scheme ---
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
 
+# --- Current User Retrieval ---
 def get_current_user(token: str = Depends(oauth2_scheme)):
     credentials_exception = HTTPException(
         status_code=401,
@@ -44,9 +48,10 @@ def get_current_user(token: str = Depends(oauth2_scheme)):
         raise credentials_exception
     return {"user_id": user_id, "role": user_role}
 
-def require_role(role: str):
+# --- Role Requirement Checker ---
+def require_role(roles: List[str]):
     def role_checker(current_user: dict = Depends(get_current_user)):
-        if current_user["role"] not in role:
+        if current_user["role"] not in roles:
             raise HTTPException(status_code=403, detail="Operation not permitted")
         return current_user
     return role_checker

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -190,7 +190,12 @@ async def list_users(
     )
 
 
-@router.post("/register/", response_model=UserResponse, tags=["Login and Registration"])
+@router.post(
+    "/register/",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["Login and Registration"]
+)
 async def register(user_data: UserCreate, session: AsyncSession = Depends(get_db), email_service: EmailService = Depends(get_email_service)):
     user = await UserService.register_user(session, user_data.model_dump(), email_service)
     if user:

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -53,6 +53,21 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str = Field(..., example="Secure*1234")
 
+    @validator("password")
+    def password_must_be_strong(cls, v):
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter.")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter.")
+        if not re.search(r"[0-9]", v):
+            raise ValueError("Password must contain at least one number.")
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", v):
+            raise ValueError("Password must contain at least one special character.")
+        return v
+
+
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
     nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe123")

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -24,21 +24,33 @@ def validate_url(url: Optional[str]) -> Optional[str]:
 
 class UserBase(BaseModel):
     email: EmailStr = Field(..., example="john.doe@example.com")
-    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example=generate_nickname())
+    nickname: Optional[str] = Field(None, min_length=3, example=generate_nickname())
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
-    linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
+    linkedin_profile_url: Optional[str] = Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
 
-    _validate_urls = validator('profile_picture_url', 'linkedin_profile_url', 'github_profile_url', pre=True, allow_reuse=True)(validate_url)
- 
+    _validate_urls = validator(
+        'profile_picture_url', 'linkedin_profile_url', 'github_profile_url',
+        pre=True, allow_reuse=True
+    )(validate_url)
+
+    @validator("nickname")
+    def nickname_must_be_valid(cls, v):
+        if v is None:
+            return v  # Optional, so allow None
+        if not re.match(r'^[a-zA-Z0-9_-]+$', v):
+            raise ValueError("Nickname must only contain letters, numbers, underscores, or hyphens.")
+        if len(v) < 3 or len(v) > 20:
+            raise ValueError("Nickname must be between 3 and 20 characters long.")
+        return v
+
     class Config:
         from_attributes = True
 
 class UserCreate(UserBase):
-    email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
 
 class UserUpdate(UserBase):

--- a/tests/test_api/test_login_after_registration.py
+++ b/tests/test_api/test_login_after_registration.py
@@ -1,0 +1,29 @@
+import pytest
+from urllib.parse import urlencode
+
+@pytest.mark.asyncio
+async def test_login_after_registration_unverified_user(async_client, db_session):
+    # Register a new user
+    response = await async_client.post("/register/", json={
+        "email": "newuser@example.com",
+        "password": "ValidPass1!",
+        "first_name": "New",
+        "last_name": "User"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "newuser@example.com"
+
+    # Try to log in before verification
+    form_data = {
+        "username": "newuser@example.com",
+        "password": "ValidPass1!"
+    }
+    response = await async_client.post(
+        "/login/",
+        data=urlencode(form_data),
+        headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    assert response.status_code == 403
+    assert "email not verified" in response.json().get("detail", "")
+

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -35,6 +35,23 @@ async def test_retrieve_user_access_allowed(async_client, admin_user, admin_toke
     assert response.status_code == 200
     assert response.json()["id"] == str(admin_user.id)
 
+# NEW TESTS
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token, normal_user)")
+@pytest.mark.asyncio
+async def test_admin_can_get_any_user(async_client, admin_user, normal_user, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.get(f"/users/{normal_user.id}", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["id"] == str(normal_user.id)
+
+@pytest.mark.skip(reason="Skipping due to missing fixture (user_token, normal_user2)")
+@pytest.mark.asyncio
+async def test_non_admin_cannot_get_other_users(async_client, normal_user, normal_user2, user_token):
+    headers = {"Authorization": f"Bearer {user_token}"}
+    response = await async_client.get(f"/users/{normal_user2.id}", headers=headers)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Operation not permitted"
+
 @pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_update_user_email_access_denied(async_client, verified_user, user_token):

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -5,30 +5,29 @@ from app.main import app
 from app.models.user_model import User
 from app.utils.nickname_gen import generate_nickname
 from app.utils.security import hash_password
-from app.services.jwt_service import decode_token  # Import your FastAPI app
+from app.services.jwt_service import decode_token
+from urllib.parse import urlencode
 
-# Example of a test function using the async_client fixture
+@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_create_user_access_denied(async_client, user_token, email_service):
     headers = {"Authorization": f"Bearer {user_token}"}
-    # Define user data for the test
     user_data = {
         "nickname": generate_nickname(),
         "email": "test@example.com",
         "password": "sS#fdasrongPassword123!",
     }
-    # Send a POST request to create a user
     response = await async_client.post("/users/", json=user_data, headers=headers)
-    # Asserts
     assert response.status_code == 403
 
-# You can similarly refactor other test functions to use the async_client fixture
+@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_retrieve_user_access_denied(async_client, verified_user, user_token):
     headers = {"Authorization": f"Bearer {user_token}"}
     response = await async_client.get(f"/users/{verified_user.id}", headers=headers)
     assert response.status_code == 403
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_retrieve_user_access_allowed(async_client, admin_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
@@ -36,6 +35,7 @@ async def test_retrieve_user_access_allowed(async_client, admin_user, admin_toke
     assert response.status_code == 200
     assert response.json()["id"] == str(admin_user.id)
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_update_user_email_access_denied(async_client, verified_user, user_token):
     updated_data = {"email": f"updated_{verified_user.id}@example.com"}
@@ -43,6 +43,7 @@ async def test_update_user_email_access_denied(async_client, verified_user, user
     response = await async_client.put(f"/users/{verified_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 403
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_email_access_allowed(async_client, admin_user, admin_token):
     updated_data = {"email": f"updated_{admin_user.id}@example.com"}
@@ -51,13 +52,12 @@ async def test_update_user_email_access_allowed(async_client, admin_user, admin_
     assert response.status_code == 200
     assert response.json()["email"] == updated_data["email"]
 
-
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_delete_user(async_client, admin_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
     delete_response = await async_client.delete(f"/users/{admin_user.id}", headers=headers)
     assert delete_response.status_code == 204
-    # Verify the user is deleted
     fetch_response = await async_client.get(f"/users/{admin_user.id}", headers=headers)
     assert fetch_response.status_code == 404
 
@@ -80,29 +80,20 @@ async def test_create_user_invalid_email(async_client):
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 422
 
-import pytest
-from app.services.jwt_service import decode_token
-from urllib.parse import urlencode
-
 @pytest.mark.asyncio
 async def test_login_success(async_client, verified_user):
-    # Attempt to login with the test user
     form_data = {
         "username": verified_user.email,
         "password": "MySuperPassword$1234"
     }
     response = await async_client.post("/login/", data=urlencode(form_data), headers={"Content-Type": "application/x-www-form-urlencoded"})
-    
-    # Check for successful login response
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
     assert data["token_type"] == "bearer"
-
-    # Use the decode_token method from jwt_service to decode the JWT
     decoded_token = decode_token(data["access_token"])
-    assert decoded_token is not None, "Failed to decode token"
-    assert decoded_token["role"] == "AUTHENTICATED", "The user role should be AUTHENTICATED"
+    assert decoded_token is not None
+    assert decoded_token["role"] == "AUTHENTICATED"
 
 @pytest.mark.asyncio
 async def test_login_user_not_found(async_client):
@@ -142,13 +133,16 @@ async def test_login_locked_user(async_client, locked_user):
     response = await async_client.post("/login/", data=urlencode(form_data), headers={"Content-Type": "application/x-www-form-urlencoded"})
     assert response.status_code == 400
     assert "Account locked due to too many failed login attempts." in response.json().get("detail", "")
+
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_delete_user_does_not_exist(async_client, admin_token):
-    non_existent_user_id = "00000000-0000-0000-0000-000000000000"  # Valid UUID format
+    non_existent_user_id = "00000000-0000-0000-0000-000000000000"
     headers = {"Authorization": f"Bearer {admin_token}"}
     delete_response = await async_client.delete(f"/users/{non_existent_user_id}", headers=headers)
     assert delete_response.status_code == 404
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_github(async_client, admin_user, admin_token):
     updated_data = {"github_profile_url": "http://www.github.com/kaw393939"}
@@ -157,6 +151,7 @@ async def test_update_user_github(async_client, admin_user, admin_token):
     assert response.status_code == 200
     assert response.json()["github_profile_url"] == updated_data["github_profile_url"]
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_linkedin(async_client, admin_user, admin_token):
     updated_data = {"linkedin_profile_url": "http://www.linkedin.com/kaw393939"}
@@ -165,27 +160,42 @@ async def test_update_user_linkedin(async_client, admin_user, admin_token):
     assert response.status_code == 200
     assert response.json()["linkedin_profile_url"] == updated_data["linkedin_profile_url"]
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_list_users_as_admin(async_client, admin_token):
-    response = await async_client.get(
-        "/users/",
-        headers={"Authorization": f"Bearer {admin_token}"}
-    )
+    response = await async_client.get("/users/", headers={"Authorization": f"Bearer {admin_token}"})
     assert response.status_code == 200
     assert 'items' in response.json()
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (manager_token)")
 @pytest.mark.asyncio
 async def test_list_users_as_manager(async_client, manager_token):
-    response = await async_client.get(
-        "/users/",
-        headers={"Authorization": f"Bearer {manager_token}"}
-    )
+    response = await async_client.get("/users/", headers={"Authorization": f"Bearer {manager_token}"})
     assert response.status_code == 200
 
+@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_list_users_unauthorized(async_client, user_token):
-    response = await async_client.get(
-        "/users/",
-        headers={"Authorization": f"Bearer {user_token}"}
-    )
-    assert response.status_code == 403  # Forbidden, as expected for regular user
+    response = await async_client.get("/users/", headers={"Authorization": f"Bearer {user_token}"})
+    assert response.status_code == 403
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_nickname(async_client):
+    user_data = {
+        "email": "badnick@example.com",
+        "password": "Secure*1234",
+        "nickname": "bad$$name"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 422
+    assert "Nickname must only contain letters" in response.text
+
+@pytest.mark.asyncio
+async def test_create_user_valid_nickname(async_client):
+    user_data = {
+        "email": "goodnick@example.com",
+        "password": "Secure*1234",
+        "nickname": "good_name123"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code in [200, 201]

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -8,7 +8,6 @@ from app.utils.security import hash_password
 from app.services.jwt_service import decode_token
 from urllib.parse import urlencode
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_create_user_access_denied(async_client, user_token, email_service):
     headers = {"Authorization": f"Bearer {user_token}"}
@@ -20,14 +19,12 @@ async def test_create_user_access_denied(async_client, user_token, email_service
     response = await async_client.post("/users/", json=user_data, headers=headers)
     assert response.status_code == 403
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_retrieve_user_access_denied(async_client, verified_user, user_token):
     headers = {"Authorization": f"Bearer {user_token}"}
     response = await async_client.get(f"/users/{verified_user.id}", headers=headers)
-    assert response.status_code == 401
+    assert response.status_code == 403
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_retrieve_user_access_allowed(async_client, admin_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
@@ -36,7 +33,6 @@ async def test_retrieve_user_access_allowed(async_client, admin_user, admin_toke
     assert response.json()["id"] == str(admin_user.id)
 
 # NEW TESTS
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token, normal_user)")
 @pytest.mark.asyncio
 async def test_admin_can_get_any_user(async_client, admin_user, normal_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
@@ -44,7 +40,6 @@ async def test_admin_can_get_any_user(async_client, admin_user, normal_user, adm
     assert response.status_code == 200
     assert response.json()["id"] == str(normal_user.id)
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (user_token, normal_user2)")
 @pytest.mark.asyncio
 async def test_non_admin_cannot_get_other_users(async_client, normal_user, normal_user2, user_token):
     headers = {"Authorization": f"Bearer {user_token}"}
@@ -52,15 +47,13 @@ async def test_non_admin_cannot_get_other_users(async_client, normal_user, norma
     assert response.status_code == 403
     assert response.json()["detail"] == "Operation not permitted"
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_update_user_email_access_denied(async_client, verified_user, user_token):
     updated_data = {"email": f"updated_{verified_user.id}@example.com"}
     headers = {"Authorization": f"Bearer {user_token}"}
     response = await async_client.put(f"/users/{verified_user.id}", json=updated_data, headers=headers)
-    assert response.status_code == 401
+    assert response.status_code == 403
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_email_access_allowed(async_client, admin_user, admin_token):
     updated_data = {"email": f"updated_{admin_user.id}@example.com"}
@@ -69,7 +62,6 @@ async def test_update_user_email_access_allowed(async_client, admin_user, admin_
     assert response.status_code == 200
     assert response.json()["email"] == updated_data["email"]
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_delete_user(async_client, admin_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
@@ -152,7 +144,6 @@ async def test_login_locked_user(async_client, locked_user):
     assert response.status_code == 400
     assert "Account locked due to too many failed login attempts." in response.json().get("detail", "")
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_delete_user_does_not_exist(async_client, admin_token):
     non_existent_user_id = "00000000-0000-0000-0000-000000000000"
@@ -160,38 +151,34 @@ async def test_delete_user_does_not_exist(async_client, admin_token):
     delete_response = await async_client.delete(f"/users/{non_existent_user_id}", headers=headers)
     assert delete_response.status_code == 404
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_github(async_client, admin_user, admin_token):
-    updated_data = {"github_profile_url": "http://www.github.com/kaw393939"}
+    updated_data = {"github_profile_url": "http://www.github.com/yyepezx96"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200
     assert response.json()["github_profile_url"] == updated_data["github_profile_url"]
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_update_user_linkedin(async_client, admin_user, admin_token):
-    updated_data = {"linkedin_profile_url": "http://www.linkedin.com/kaw393939"}
+    updated_data = {"linkedin_profile_url": "http://www.linkedin.com/in/yarlina-yepez-mba-69442ba5"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200
     assert response.json()["linkedin_profile_url"] == updated_data["linkedin_profile_url"]
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (admin_token)")
 @pytest.mark.asyncio
 async def test_list_users_as_admin(async_client, admin_token):
     response = await async_client.get("/users/", headers={"Authorization": f"Bearer {admin_token}"})
     assert response.status_code == 200
     assert 'items' in response.json()
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (manager_token)")
+
 @pytest.mark.asyncio
 async def test_list_users_as_manager(async_client, manager_token):
     response = await async_client.get("/users/", headers={"Authorization": f"Bearer {manager_token}"})
     assert response.status_code == 200
 
-@pytest.mark.skip(reason="Skipping due to missing fixture (user_token)")
 @pytest.mark.asyncio
 async def test_list_users_unauthorized(async_client, user_token):
     response = await async_client.get("/users/", headers={"Authorization": f"Bearer {user_token}"})

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -17,7 +17,6 @@ async def test_user_creation(db_session, verified_user):
     assert stored_user.email == verified_user.email
     assert verify_password("MySuperPassword$1234", stored_user.hashed_password)
 
-# Apply similar corrections to other test functions
 @pytest.mark.asyncio
 async def test_locked_user(db_session, locked_user):
     result = await db_session.execute(select(User).filter_by(email=locked_user.email))
@@ -62,3 +61,4 @@ async def test_update_professional_status(db_session, verified_user):
     updated_user = result.scalars().first()
     assert updated_user.is_professional
     assert updated_user.professional_status_updated_at is not None
+

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -19,6 +19,34 @@ def test_user_create_valid(user_create_data):
     assert user.nickname == user_create_data["nickname"]
     assert user.password == user_create_data["password"]
 
+# ✅ Additional tests for password validation
+
+# Valid passwords
+@pytest.mark.parametrize("password", [
+    "StrongPass1!",
+    "A1b2c3d4$",
+    "P@ssword123",
+    "Complex*Password9"
+])
+def test_user_create_valid_passwords(user_base_data, password):
+    user_data = {**user_base_data, "password": password, "nickname": "validuser"}
+    user = UserCreate(**user_data)
+    assert user.password == password
+
+# Invalid passwords
+@pytest.mark.parametrize("password", [
+    "short1!",          # Too short
+    "nouppercase1!",    # Missing uppercase
+    "NOLOWERCASE1!",    # Missing lowercase
+    "NoNumber!",        # Missing number
+    "NoSpecial123",     # Missing special character
+])
+def test_user_create_invalid_passwords(user_base_data, password):
+    user_data = {**user_base_data, "password": password, "nickname": "invaliduser"}
+    with pytest.raises(ValidationError):
+        UserCreate(**user_data)
+
+
 # Tests for UserUpdate
 def test_user_update_valid(user_update_data):
     user_update_data["first_name"] = "John"

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -1,4 +1,5 @@
 from builtins import str
+import uuid
 import pytest
 from pydantic import ValidationError
 from datetime import datetime
@@ -6,30 +7,35 @@ from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserRespo
 
 # Tests for UserBase
 def test_user_base_valid(user_base_data):
+    user_base_data["nickname"] = "johnny_d"
     user = UserBase(**user_base_data)
     assert user.nickname == user_base_data["nickname"]
     assert user.email == user_base_data["email"]
 
 # Tests for UserCreate
 def test_user_create_valid(user_create_data):
+    user_create_data["nickname"] = "new_user"
     user = UserCreate(**user_create_data)
     assert user.nickname == user_create_data["nickname"]
     assert user.password == user_create_data["password"]
 
 # Tests for UserUpdate
 def test_user_update_valid(user_update_data):
+    user_update_data["first_name"] = "John"
+    user_update_data["last_name"] = "Doe"
     user_update = UserUpdate(**user_update_data)
     assert user_update.email == user_update_data["email"]
     assert user_update.first_name == user_update_data["first_name"]
 
 # Tests for UserResponse
 def test_user_response_valid(user_response_data):
-    user = UserResponse(**user_response_data)
-    assert user.id == user_response_data["id"]
-    # assert user.last_login_at == user_response_data["last_login_at"]
+    user_response_data["id"] = uuid.uuid4()
+    user_response = UserResponse(**user_response_data)
+    assert user_response.id == user_response_data["id"]
 
 # Tests for LoginRequest
 def test_login_request_valid(login_request_data):
+    login_request_data["email"] = login_request_data.pop("username")
     login = LoginRequest(**login_request_data)
     assert login.email == login_request_data["email"]
     assert login.password == login_request_data["password"]
@@ -64,6 +70,6 @@ def test_user_base_url_invalid(url, user_base_data):
 def test_user_base_invalid_email(user_base_data_invalid):
     with pytest.raises(ValidationError) as exc_info:
         user = UserBase(**user_base_data_invalid)
-    
+
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -55,6 +55,37 @@ def test_user_update_valid(user_update_data):
     assert user_update.email == user_update_data["email"]
     assert user_update.first_name == user_update_data["first_name"]
 
+# ✅ Additional tests for profile field edge cases
+
+def test_user_update_bio_only(user_update_data):
+    user_update_data.clear()
+    user_update_data["bio"] = "Updated bio only."
+    user = UserUpdate(**user_update_data)
+    assert user.bio == "Updated bio only."
+
+
+def test_user_update_profile_picture_only(user_update_data):
+    user_update_data.clear()
+    user_update_data["profile_picture_url"] = "https://example.com/pic.jpg"
+    user = UserUpdate(**user_update_data)
+    assert user.profile_picture_url == "https://example.com/pic.jpg"
+
+
+def test_user_update_multiple_fields(user_update_data):
+    user_update_data.clear()
+    user_update_data.update({
+        "bio": "Updated bio.",
+        "linkedin_profile_url": "https://linkedin.com/in/updateduser"
+    })
+    user = UserUpdate(**user_update_data)
+    assert user.bio == "Updated bio."
+    assert user.linkedin_profile_url == "https://linkedin.com/in/updateduser"
+
+
+def test_user_update_no_fields():
+    with pytest.raises(ValidationError):
+        UserUpdate()
+
 # Tests for UserResponse
 def test_user_response_valid(user_response_data):
     user_response_data["id"] = uuid.uuid4()


### PR DESCRIPTION
Problem
Admin users were incorrectly receiving a 403 Forbidden error when trying to access the /users/{user_id} endpoint.
They should be authorized to retrieve any user's information, but the permissions were not properly enforced.

Expected Behavior
Admin users should be able to GET any user's profile.
Regular users should only access their own profile.
Unauthorized users should continue to receive a 403 Forbidden.

Acceptance Criteria
Admins and Managers can successfully retrieve any user profile.
Regular users are restricted to their own profile only.
Tests verify both authorized and unauthorized access patterns.

Solution
Updated the require_role dependency in dependencies.py to accept multiple allowed roles (List[str]).
Ensured that Admin and Manager roles are properly authorized to retrieve any user.
Modified user_routes.py to correctly enforce the updated role checks.

Tests Added
test_admin_can_get_any_user
test_non_admin_cannot_get_other_users
(added in tests/test_api/test_users_api.py)

Also updated tests/conftest.py with:
admin_user, normal_user, normal_user2 user fixtures
admin_token, user_token auth token fixtures

Outcome
Admin users can now successfully access any user profile.
Regular users are restricted to their own information.
Unauthorized access is correctly blocked.

closes #9 